### PR TITLE
addCustomOverlay할때마다 overlay를 전체적으로 다시 그리는 현상 개선

### DIFF
--- a/lib/src/basic/kakao_map.dart
+++ b/lib/src/basic/kakao_map.dart
@@ -352,6 +352,16 @@ class _KakaoMapState extends State<KakaoMap> {
 
     customOverlays = [];
   }
+  
+  function clearNoLongerPresentOverlay(ids) {
+    customOverlays = customOverlays.filter(overlay => {
+      if (!ids.includes(overlay.id)) {
+        overlay.setMap(null);
+        return false;
+      }
+      return true;
+    });
+  }
 
   function clear() {
     clearPolyline();
@@ -710,8 +720,31 @@ class _KakaoMapState extends State<KakaoMap> {
 
     return newObj;
   }
-
+  
   function addCustomOverlay(customOverlayId, latLng, content, isClickable, xAnchor, yAnchor, zIndex) {
+    let customOverlay = makeOverlay(customOverlayId, latLng, content, isClickable, xAnchor, yAnchor, zIndex); 
+    
+    customOverlay['id'] = customOverlayId;
+    
+    customOverlays.push(customOverlay);
+
+    customOverlay.setMap(map);
+  }
+  
+  function addCustomOverlayIfNotExist(customOverlayId, latLng, content, isClickable, xAnchor, yAnchor, zIndex) {
+    // customOverlays에 동일한 ID가 있는지 확인
+    if (customOverlays.some(existingOverlay => existingOverlay.id === customOverlayId)) {
+      return;
+    }
+      
+    const customOverlay = makeOverlay(customOverlayId, latLng, content, isClickable, xAnchor, yAnchor, zIndex); 
+    customOverlay['id'] = customOverlayId;
+    customOverlays.push(customOverlay);
+    customOverlay.setMap(map);
+  }
+  
+  
+  function makeOverlay(customOverlayId, latLng, content, isClickable, xAnchor, yAnchor, zIndex) {
     latLng = JSON.parse(latLng);
     let markerPosition = new kakao.maps.LatLng(latLng.latitude, latLng.longitude); // 마커가 표시될 위치입니다
     isClickable = Boolean(isClickable);
@@ -725,8 +758,7 @@ class _KakaoMapState extends State<KakaoMap> {
         '`, `' + latLng.longitude +
         '`)">' + content + '</div>';
     }
-
-    let customOverlay = new kakao.maps.CustomOverlay({
+    return new kakao.maps.CustomOverlay({
       map: map,
       clickable: isClickable,
       content: content,
@@ -735,14 +767,9 @@ class _KakaoMapState extends State<KakaoMap> {
       yAnchor: yAnchor,
       zIndex: zIndex,
     });
-    
-    customOverlay['id'] = customOverlayId;
-    
-    customOverlays.push(customOverlay);
-
-    customOverlay.setMap(map);
   }
-
+  
+  
   function addCustomOverlayListener(customOverlayId, latitude, longitude) {
     // 클릭한 위도, 경도 정보를 가져옵니다
     let latLng = new kakao.maps.LatLng(latitude, longitude); // 마커가 표시될 위치입니다

--- a/lib/src/basic/kakao_map_controller.dart
+++ b/lib/src/basic/kakao_map_controller.dart
@@ -152,7 +152,6 @@ class KakaoMapController {
   }
 
   clearNoLongerPresentOverlay({required List<String> newOverlayIds}) async {
-    String ids = jsonEncode(newOverlayIds);
     _webViewController.runJavaScript("clearNoLongerPresentOverlay('${jsonEncode(newOverlayIds)}');");
   }
 

--- a/lib/src/basic/kakao_map_controller.dart
+++ b/lib/src/basic/kakao_map_controller.dart
@@ -85,6 +85,17 @@ class KakaoMapController {
         .runJavaScript("setMarkerDraggable('$markerId', $draggable);");
   }
 
+  /// Accepts a new list to update the existing overlay by retaining overlapping elements, adding new ones, and removing those no longer present.
+  /// addCustomOverlay 사용 시 customOverlay 들을 다시 그리는 현상을 방지하기 위해 사용
+  mergeAnsSyncOverlay({required List<CustomOverlay> customOverlays}) async {
+    clearNoLongerPresentOverlay(newOverlayIds: customOverlays.map((e) => e.customOverlayId).toList());
+
+    for (var customOverlay in customOverlays) {
+      await _webViewController.runJavaScript(
+          "addCustomOverlayIfNotExist('${customOverlay.customOverlayId}', '${jsonEncode(customOverlay.latLng)}', '${customOverlay.content}', '${customOverlay.isClickable}', '${customOverlay.xAnchor}', '${customOverlay.yAnchor}', '${customOverlay.zIndex}')");
+    }
+  }
+
   /// draw custom overlay
   addCustomOverlay({List<CustomOverlay>? customOverlays}) async {
     if (customOverlays != null) {
@@ -138,6 +149,11 @@ class KakaoMapController {
   /// clear custom overlay
   clearCustomOverlay() {
     _webViewController.runJavaScript('clearCustomOverlay();');
+  }
+
+  clearNoLongerPresentOverlay({required List<String> newOverlayIds}) async {
+    String ids = jsonEncode(newOverlayIds);
+    _webViewController.runJavaScript("clearNoLongerPresentOverlay('${jsonEncode(newOverlayIds)}');");
   }
 
   /// move to center


### PR DESCRIPTION
현재 addCustomOverlay를 하면 전체 overlay를 지도에서 지우고 새로 다시 그리고 있습니다.
이로 인해 overlay를 그릴 때 반짝 거리는 현상이 있으며 갯수가 많아지면 성능에 영향을 미칩니다.
이것을 개선하고자 새로 표시할 overlay들을 전달하면 지울건 지우고 내비둘건 내비두고 새로운 것은 새로 그리는 mergeAnsSyncOverlay 함수를 구현했습니다.